### PR TITLE
Fix SMS deduplication deletion list

### DIFF
--- a/src/SmsReader/SmsReader.cpp
+++ b/src/SmsReader/SmsReader.cpp
@@ -878,9 +878,11 @@ void QmiSmsReader::processAllSMS(MessageSyncContext *ctx) {
       }
       
       // 删除多余的分段
-      // 由于这是静态方法，我们不能直接调用deleteMessage
-      // 将待删除的索引添加到上下文中，让调用者处理删除操作
-      ctx->toDeleteIndices = toDeleteIndices;
+      // 由于这是静态方法，我们不能直接调用 deleteMessage
+      // 将待删除的索引追加到上下文中，让调用者统一处理删除操作
+      ctx->toDeleteIndices.insert(ctx->toDeleteIndices.end(),
+                                  toDeleteIndices.begin(),
+                                  toDeleteIndices.end());
       
       // 更新parts列表为去重后的列表
       parts = uniqueParts;


### PR DESCRIPTION
## Summary
- accumulate indices of duplicate SMS parts instead of overwriting

## Testing
- `apt-get update`
- `apt-get install -y libglib2.0-dev`
- `apt-get install -y libqmi-glib-dev`
- `xmake --root` *(fails: fatal error: glib-unix.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_683fe0907a1c832daf095ab5bb4b5c42