### PR TITLE
Fix build by using pkgconfig for qmi-glib

### DIFF
--- a/xmake.lua
+++ b/xmake.lua
@@ -3,8 +3,15 @@ add_rules("mode.debug", "mode.release")
 add_requires("ixwebsocket", {configs = {use_tls = true, ssl = "mbedtls"}})
 add_requires("yaml-cpp", {configs = {shared = false}})
 add_requires("glog", {configs = {shared = false}})
-add_requires("glib-2.0", {system = true})
-add_requires("qmi-glib", {system = true})
+-- Use pkg-config to locate glib and qmi-glib on the system
+-- The default packages provided by xmake do not expose the
+-- correct include directories for qmi-glib, which results in
+-- missing headers such as <libqmi-glib.h>. Using the pkgconfig
+-- variants ensures that the proper compiler and linker flags
+-- are gathered from the system *.pc files.
+
+add_requires("pkgconfig::glib-2.0")
+add_requires("pkgconfig::qmi-glib")
 add_requires("cppcodec", "nlohmann_json")
 
 add_repositories("local-repo build")
@@ -25,7 +32,7 @@ target("qmi_sms_reader")
     add_defines("DESKTOP_PDU")
     add_files("PDUlib/src/*.cpp")
 
-    add_packages("openssl", "cppcodec", "yaml-cpp", "ixwebsocket-custom", "nlohmann_json", "glog", "glib-2.0", "qmi-glib")
+    add_packages("openssl", "cppcodec", "yaml-cpp", "ixwebsocket-custom", "nlohmann_json", "glog", "pkgconfig::glib-2.0", "pkgconfig::qmi-glib")
     add_links("gio-2.0", "gobject-2.0", "glib-2.0")
 
     add_ldflags("-static-libgcc", "-static-libstdc++", "-Wl,-Bstatic -lc -Wl,-Bdynamic")


### PR DESCRIPTION
## Summary
- use pkgconfig to get qmi-glib include paths

## Testing
- `xmake --root -v`

------
https://chatgpt.com/codex/tasks/task_e_684244b2aa00832db606b91fb3248d41